### PR TITLE
The default PHP version should be one available in the container

### DIFF
--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -34,7 +34,7 @@ private def buildTag() {
 
 private def runContainers(Map pipelineParams = [:], Closure body) {
 
-    def php = pipelineParams.php ?: '7.2'
+    def php = pipelineParams.php ?: '7.4'
     def db = pipelineParams.db ?: 'mysql'
     def withBehatServers = pipelineParams.withBehatServers
 


### PR DESCRIPTION
I noticed that the default PHP version was lower than the minimum version supported by the docker image now, it seem to be worth bumping it.