### PR TITLE
Allow version of moodle-plugin-ci to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This starts up a docker container with a suitable environment for running moodle
 * **db**: mysql or postgres
 * **withBehatServers**: chrome or firefox. This will start the relevant selenium container and the PHP
   built-in web server to allow the behat command to be run.
+* **ciVersion** the version of moodle-plugin-ci to use
   
 The step also expects a code block which will be run inside the container
 
@@ -113,7 +114,7 @@ For example:
 
                 steps {
 
-                    withMoodlePluginCiContainer(php: '7.4') {
+                    withMoodlePluginCiContainer(php: '7.4', ciVersion: '4') {
 
                         moodlePluginCiInstall("--branch MOODLE_310_STABLE --plugin plugin")
 

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -36,6 +36,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
 
     def php = pipelineParams.php ?: '7.2'
     def db = pipelineParams.db ?: 'mysql'
+    def ciVersion = pipelineParams.ciVersion ?: '3';
     def withBehatServers = pipelineParams.withBehatServers
 
     if (withBehatServers) {
@@ -119,7 +120,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
 
         withEnv(installEnv) {
             // Install plugin ci.
-            sh 'composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3'
+            sh "composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }
 
         // Preload env file with variables to work around withEnv not apparently being picked up by symfony.


### PR DESCRIPTION
I was playing around looking for a solution to get two different runs happening in one job, while the solution is not bumping the version of moodle-plugin-ci this seems like it could be a beneficial change.

If it is not specified in the step it will continue to use version 3