### PR TITLE
12 node version issues

### DIFF
--- a/resources/uk/ac/strath/myplace/Dockerfile
+++ b/resources/uk/ac/strath/myplace/Dockerfile
@@ -65,6 +65,7 @@ RUN locale-gen en_AU.UTF-8
 # Also it's needed for the post-install step of the create project for moodle-plugin-ci
 # From https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
 ENV NVM_DIR /var/lib/nvm
+ENV PATH="${PATH}:${NVM_DIR}"
 
 RUN mkdir $NVM_DIR \
     && chown jenkins:jenkins $NVM_DIR

--- a/resources/uk/ac/strath/myplace/Dockerfile
+++ b/resources/uk/ac/strath/myplace/Dockerfile
@@ -74,7 +74,7 @@ USER jenkins
 # Install NVM and grunt-cli
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
-    && nvm install lts/carbon \
+    && nvm install --lts \
     && npm install -g grunt-cli
 
 USER postgres

--- a/resources/uk/ac/strath/myplace/Dockerfile
+++ b/resources/uk/ac/strath/myplace/Dockerfile
@@ -65,7 +65,6 @@ RUN locale-gen en_AU.UTF-8
 # Also it's needed for the post-install step of the create project for moodle-plugin-ci
 # From https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
 ENV NVM_DIR /var/lib/nvm
-ENV PATH="${PATH}:${NVM_DIR}"
 
 RUN mkdir $NVM_DIR \
     && chown jenkins:jenkins $NVM_DIR

--- a/resources/uk/ac/strath/myplace/Dockerfile
+++ b/resources/uk/ac/strath/myplace/Dockerfile
@@ -74,7 +74,7 @@ USER jenkins
 # Install NVM and grunt-cli
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
-    && nvm install --lts \
+    && nvm install lts/carbon \
     && npm install -g grunt-cli
 
 USER postgres

--- a/resources/uk/ac/strath/myplace/Dockerfile
+++ b/resources/uk/ac/strath/myplace/Dockerfile
@@ -65,25 +65,17 @@ RUN locale-gen en_AU.UTF-8
 # Also it's needed for the post-install step of the create project for moodle-plugin-ci
 # From https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
 ENV NVM_DIR /var/lib/nvm
-ENV NODE_VERSION 16.19.1
 
 RUN mkdir $NVM_DIR \
     && chown jenkins:jenkins $NVM_DIR
 
 USER jenkins
 
-# Install NVM
-RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
+# Install NVM and grunt-cli
+RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default
-
-ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# Install grunt CLI.
-RUN npm install -g grunt-cli
+    && nvm install --lts \
+    && npm install -g grunt-cli
 
 USER postgres
 # Create jenkins user. There's probably a better way to do this.

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -90,7 +90,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
     // Nasty hack to get around the fact that we can't use withEnv to change the PATH on a container
     // (or any other method as far as I can see)
     // https://issues.jenkins.io/browse/JENKINS-49076
-    def originalDockerPath = "/var/lib/nvm/versions/node/v16.19.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    def originalDockerPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     def pathOnDocker = "${WORKSPACE}/ci/bin:${originalDockerPath}"
 
     image.inside("-e PATH=${pathOnDocker} --network ${buildTag} --network-alias=moodle") {
@@ -118,6 +118,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
         }
 
         withEnv(installEnv) {
+            sh ". $NVM_DIR/nvm.sh"
             // Install plugin ci.
             sh "composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -20,7 +20,6 @@ def call(Map pipelineParams = [:], Closure body) {
         sh "docker rmi --no-prune ${buildTag} || true"
     }
 
-
 }
 
 private def buildTag() {

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -118,9 +118,8 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
         }
 
         withEnv(installEnv) {
-            sh ". \$NVM_DIR/nvm.sh && nvm use default"
-            // Install plugin ci.
-            sh "composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
+            sh ". \$NVM_DIR/nvm.sh && nvm use default && \
+                composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }
 
         // Preload env file with variables to work around withEnv not apparently being picked up by symfony.

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -118,7 +118,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
         }
 
         withEnv(installEnv) {
-            sh ". $NVM_DIR/nvm.sh"
+            sh ". \$NVM_DIR/nvm.sh"
             // Install plugin ci.
             sh "composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -118,7 +118,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
         }
 
         withEnv(installEnv) {
-            sh ". \$NVM_DIR/nvm.sh && nvm use default && \
+            sh ". \$NVM_DIR/nvm.sh >/dev/null && nvm use default && \
                 composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }
 

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -118,7 +118,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
         }
 
         withEnv(installEnv) {
-            sh ". \$NVM_DIR/nvm.sh && nvm use"
+            sh ". \$NVM_DIR/nvm.sh && nvm use default"
             // Install plugin ci.
             sh "composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }

--- a/vars/withMoodlePluginCiContainer.groovy
+++ b/vars/withMoodlePluginCiContainer.groovy
@@ -118,7 +118,7 @@ private def runContainers(Map pipelineParams = [:], Closure body) {
         }
 
         withEnv(installEnv) {
-            sh ". \$NVM_DIR/nvm.sh"
+            sh ". \$NVM_DIR/nvm.sh && nvm use"
             // Install plugin ci.
             sh "composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^${ciVersion}"
         }


### PR DESCRIPTION
This fixes #12 

It's basically removing the NODE_VERSION environment variable that was preventing nvm from installing the correct version from Moodle's .nvmrc file.

I tested it and it is working. I also checked that it doesn't just happen to be working on account of Moodle 4.3 having the latest LTS version in its .nvmrc at the moment. I set the nvm install in the Dockerfile to use an ancient version (lts/carbon) as the default, which is used to install grunt-cli, and it still worked (moodle-plugin-ci itself used nvm to install and enable lts/iron)